### PR TITLE
Upgrade jetbrains compose gradle plugin

### DIFF
--- a/buildSrc/src/main/java/ComposeDesktopDependencies.kt
+++ b/buildSrc/src/main/java/ComposeDesktopDependencies.kt
@@ -1,5 +1,5 @@
 object ComposeDesktopDependencyVersions {
-  const val composeDesktopWeb = "1.2.0-alpha01-dev620"
+  const val composeDesktopWeb = "1.2.0-alpha01-dev686"
 
 }
 

--- a/compose-desktop/src/jvmMain/kotlin/Main.kt
+++ b/compose-desktop/src/jvmMain/kotlin/Main.kt
@@ -1,6 +1,12 @@
 import androidx.compose.material.MaterialTheme
 import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import com.mutualmobile.harvestKmp.di.initSharedDependencies
@@ -8,7 +14,16 @@ import com.mutualmobile.harvestKmp.di.initSharedDependencies
 @Composable
 @Preview
 fun App() {
-    MaterialTheme {}
+    MaterialTheme {
+      Column {
+        Text(
+          text = "Hello KMM Desktop!",
+          modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+        )
+      }
+    }
 }
 
 fun main() = application {


### PR DESCRIPTION
## Description

Upgrade jetbrains compose gradle plugin to `1.2.0-alpha01-dev686`, to make compose desktop work with Kotlin 1.6.21.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
